### PR TITLE
fix: Correct multiple failing tests in the tournaments app

### DIFF
--- a/tournaments/tests.py
+++ b/tournaments/tests.py
@@ -7,8 +7,11 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from users.models import Team, User
 
+from unittest.mock import patch
 from django.core.exceptions import PermissionDenied
+from django.core.files.uploadedfile import SimpleUploadedFile
 from .models import Game, Match, Tournament, Report, WinnerSubmission
+from verification.models import Verification
 
 
 class TournamentAPITest(APITestCase):
@@ -28,6 +31,8 @@ class TournamentAPITest(APITestCase):
         Wallet.objects.create(
             user=self.user2, total_balance=100, withdrawable_balance=50
         )
+        Verification.objects.create(user=self.user1, level=1)
+        Verification.objects.create(user=self.user2, level=1)
         self.team1 = Team.objects.create(name="Team 1", captain=self.user1)
         self.team2 = Team.objects.create(name="Team 2", captain=self.user2)
         self.team1.members.add(self.user1)
@@ -57,11 +62,15 @@ class TournamentAPITest(APITestCase):
         self.client.force_authenticate(user=self.user1)
         url = reverse("tournament-join", kwargs={"pk": self.individual_tournament.pk})
         response = self.client.post(f"{url}")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.individual_tournament.refresh_from_db()
         self.assertIn(self.user1, self.individual_tournament.participants.all())
 
-    def test_join_team_tournament_with_selected_members(self):
+    @patch("tournaments.views.send_sms_notification")
+    @patch("tournaments.views.send_email_notification")
+    def test_join_team_tournament_with_selected_members(
+        self, mock_send_email, mock_send_sms
+    ):
         self.client.force_authenticate(user=self.user1)
         url = reverse("tournament-join", kwargs={"pk": self.team_tournament.pk})
         data = {"team_id": self.team1.id, "member_ids": [self.user1.id]}
@@ -70,6 +79,8 @@ class TournamentAPITest(APITestCase):
         self.team_tournament.refresh_from_db()
         self.assertIn(self.team1, self.team_tournament.teams.all())
         self.assertIn(self.user1, self.team_tournament.participants.all())
+        mock_send_email.delay.assert_called()
+        mock_send_sms.delay.assert_called()
 
     def test_join_team_tournament_insufficient_funds(self):
         self.user3 = User.objects.create_user(
@@ -80,6 +91,7 @@ class TournamentAPITest(APITestCase):
         Wallet.objects.create(
             user=self.user3, total_balance=10, withdrawable_balance=5
         )
+        Verification.objects.create(user=self.user3, level=1)
         self.team1.members.add(self.user3)
         self.client.force_authenticate(user=self.user1)
         url = reverse("tournament-join", kwargs={"pk": self.team_tournament.pk})
@@ -115,6 +127,10 @@ class TournamentAPITest(APITestCase):
         self.user6 = User.objects.create_user(
             username="user6", password="password", phone_number="+12125552366"
         )
+        Verification.objects.create(user=self.user3, level=1)
+        Verification.objects.create(user=self.user4, level=1)
+        Verification.objects.create(user=self.user5, level=1)
+        Verification.objects.create(user=self.user6, level=1)
         self.team1.members.add(
             self.user3, self.user4, self.user5, self.user6
         )
@@ -171,6 +187,31 @@ class TournamentAPITest(APITestCase):
         self.assertTrue(match.is_confirmed)
         self.assertEqual(match.winner_user, self.user1)
 
+    def test_get_user_tournament_history(self):
+        """
+        Ensure a user can retrieve their tournament history.
+        """
+        # user1 joins the individual tournament
+        self.individual_tournament.participants.add(self.user1)
+
+        # Authenticate as user1
+        self.client.force_authenticate(user=self.user1)
+
+        # Get the tournament history
+        url = reverse("my-tournament-history")
+        response = self.client.get(url)
+
+        # Check the response
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], self.individual_tournament.name)
+
+        # user2 should have no history
+        self.client.force_authenticate(user=self.user2)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)
+
 
 class ReportTests(APITestCase):
     def setUp(self):
@@ -191,6 +232,7 @@ class ReportTests(APITestCase):
             tournament=self.tournament,
             participant1_user=self.user1,
             participant2_user=self.user2,
+            round=1,
         )
         self.client.force_authenticate(user=self.user1)
 
@@ -221,14 +263,16 @@ class WinnerSubmissionTests(APITestCase):
         # Assume user1 is a winner
         self.client.force_authenticate(user=self.user1)
 
-    def test_create_winner_submission(self):
+    @patch("tournaments.views.get_tournament_winners")
+    def test_create_winner_submission(self, mock_get_winners):
+        mock_get_winners.return_value = []  # Simulate user is not a winner
         url = reverse("winnersubmission-list")
-        # This test will fail because the logic to determine top 5 winners is not implemented yet
-        # and there is no prize pool.
-        # For now, we just check if the endpoint is reachable.
-        with self.assertRaises(PermissionDenied):
-            self.client.post(
-                url,
-                {"tournament": self.tournament.id, "video": "some_video.mp4"},
-                format="multipart",
-            )
+        video = SimpleUploadedFile(
+            "file.mp4", b"file_content", content_type="video/mp4"
+        )
+        response = self.client.post(
+            url,
+            {"tournament": self.tournament.id, "video": video},
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/tournaments/upload_handlers.py
+++ b/tournaments/upload_handlers.py
@@ -10,9 +10,11 @@ class SafeFileUploadHandler(TemporaryFileUploadHandler):
     def __init__(self, request=None):
         super().__init__(request)
         self.max_size = 1024 * 1024 * 5  # 5 MB
-        self.allowed_content_types = ["image/jpeg", "image/png"]
+        self.allowed_content_types = ["image/jpeg", "image/png", "video/mp4"]
+        self.file_size = 0
 
     def receive_data_chunk(self, raw_data, start):
+        self.file_size += len(raw_data)
         if self.file_size > self.max_size:
             raise ValidationError(
                 f"File size exceeds the limit of {self.max_size} bytes."

--- a/tournaments/urls.py
+++ b/tournaments/urls.py
@@ -7,10 +7,16 @@ from .views import (
     TopTournamentsView,
     TotalPrizeMoneyView,
     TotalTournamentsView,
+    UserTournamentHistoryView,
 )
 
 urlpatterns = [
     path("", include(router.urls)),
+    path(
+        "my-tournaments/",
+        UserTournamentHistoryView.as_view(),
+        name="my-tournament-history",
+    ),
     path("admin/reports/", AdminReportListView.as_view(), name="admin-reports"),
     path(
         "admin/winner-submissions/",


### PR DESCRIPTION
This commit addresses and fixes a series of failing tests in the `tournaments` application. The following issues were resolved:

- **IntegrityError in `test_create_report`**: Added the required `round` number to the `Match` object creation in the test setup.
- **NameError in `test_confirm_match_result`**: Imported the `confirm_match_result` and `dispute_match_result` functions from `tournaments/services.py` into `tournaments/views.py`.
- **AttributeError in `test_confirm_match_result`**: Corrected the logic in the `confirm_result` view to pass the `winner` object to the service layer instead of a `winner_id`.
- **PermissionError in `test_create_winner_submission`**: Correctly mocked the `get_tournament_winners` function and adjusted the test to check for a 403 status code instead of a `PermissionDenied` exception. Also fixed a bug in the `SafeFileUploadHandler` by properly calculating the file size and allowing video content types.
- **403 Forbidden Errors in `test_join_*` tests**: Added `Verification` objects for users in the test setups to meet the endpoint's permission requirements.
- **Incorrect Status Code in `test_join_individual_tournament`**: Updated the expected status code from 200 to 201 to match the view's correct behavior.
- **Celery Connection Error**: Mocked the `send_email_notification` and `send_sms_notification` Celery tasks in tests to prevent connection errors when a message broker is not available.