### PR TITLE
Fix Docker Compose and Nginx configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 version: "3.8"
 
+networks:
+  main_network:
+    driver: bridge
+
 services:
   db:
     image: postgres:13
@@ -11,11 +15,15 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
+    networks:
+      - main_network
 
   redis:
     image: redis:7
     ports:
       - "6379:6379"
+    networks:
+      - main_network
 
   web:
     build: .
@@ -31,11 +39,13 @@ services:
     depends_on:
       - db
       - redis
+    networks:
+      - main_network
 
   daphne:
     build: .
     entrypoint: /app/entrypoint.sh
-    command: daphne daphne -b 0.0.0.0 -p 8001 tournament_project.asgi:application
+    command: daphne -b 0.0.0.0 -p 8001 tournament_project.asgi:application
     volumes:
       - static_volume:/app/staticfiles
       - media_volume:/app/media
@@ -46,6 +56,13 @@ services:
     depends_on:
       - db
       - redis
+    healthcheck:
+      test: ["CMD-SHELL", "exec 6<>/dev/tcp/127.0.0.1/8001; echo -e 'GET / HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&6; grep -q 'HTTP/1.1 200 OK' <&6"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - main_network
 
   celery_worker:
     build: .
@@ -56,6 +73,8 @@ services:
     depends_on:
       - db
       - redis
+    networks:
+      - main_network
 
   celery_beat:
     build: .
@@ -66,6 +85,8 @@ services:
     depends_on:
       - db
       - redis
+    networks:
+      - main_network
 
   nginx:
     image: nginx:1.25
@@ -79,8 +100,12 @@ services:
       - "80:80"
       - "443:443"
     depends_on:
-      - web
-      - daphne
+      web:
+        condition: service_started
+      daphne:
+        condition: service_healthy
+    networks:
+      - main_network
 
 volumes:
   postgres_data:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,10 +2,6 @@ upstream web {
     server web:8000;
 }
 
-upstream daphne {
-    server daphne:8001;
-}
-
 # Redirect all HTTP traffic to HTTPS
 server {
     listen 80;
@@ -18,10 +14,13 @@ server {
     server_name _;
 
     # SSL Configuration
-    ssl_certificate /etc/nginx/conf.d/self-signed.crt;
-    ssl_certificate_key /etc/nginx/conf.d/self-signed.key;
+    ssl_certificate /etc/nginx/self-signed.crt;
+    ssl_certificate_key /etc/nginx/self-signed.key;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384';
+
+    # DNS resolver for Docker's internal network
+    resolver 127.0.0.11 valid=30s;
 
     # Security Headers
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
@@ -39,7 +38,8 @@ server {
     }
 
     location /ws/ {
-        proxy_pass http://daphne;
+        set $daphne_host "daphne:8001";
+        proxy_pass http://$daphne_host;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
This commit resolves issues with the Docker Compose and Nginx setup for the Django project.

The key changes are:

1.  **`docker-compose.yml`:**
    *   A healthcheck has been added to the `daphne` service to ensure it is fully running before other services depend on it.
    *   The `nginx` service now has a `depends_on` condition that waits for the `daphne` service to be healthy, preventing startup race conditions.
    *   All services have been placed on a shared bridge network called `main_network` to ensure reliable service discovery and communication.

2.  **`nginx/nginx.conf`:**
    *   The SSL certificate and key paths have been corrected to match the volume mounts defined in `docker-compose.yml`.
    *   A `resolver` directive has been added to use Docker's internal DNS resolver (`127.0.0.11`). This allows Nginx to resolve service names at request time.
    *   The `daphne` upstream is now referenced using a variable to force dynamic resolution, which prevents the "host not found" error if Nginx starts before Daphne is registered with the DNS.
    *   The static `upstream daphne` block has been removed as it is no longer necessary with the dynamic resolver.

These changes ensure that Nginx can reliably connect to the Daphne service, that SSL is configured correctly, and that the services start in the correct order.