### PR TITLE
Fix pyopenssl and cryptography version conflict

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -50,3 +50,4 @@ twilio==9.7.0
 aiohttp==3.12.15
 smsir-python==1.0.8
 pillow==11.3.0
+pyopenssl

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ black==25.1.0
     # via -r requirements.in
 boto3==1.40.10
     # via -r requirements.in
-botocore==1.40.10
+botocore==1.40.11
     # via
     #   boto3
     #   s3transfer
@@ -85,7 +85,7 @@ constantly==23.10.4
     # via twisted
 coverage==7.10.3
     # via -r requirements.in
-cryptography==45.0.6
+cryptography==44.0.3
     # via
     #   autobahn
     #   pyopenssl
@@ -245,8 +245,10 @@ pyjwt==2.10.1
     #   djangorestframework-simplejwt
     #   social-auth-core
     #   twilio
-pyopenssl==22.0.0
-    # via twisted
+pyopenssl==24.3.0
+    # via
+    #   -r requirements.in
+    #   twisted
 pyproject-hooks==1.2.0
     # via
     #   build


### PR DESCRIPTION
The previous version of pyopenssl (22.0.0) was incompatible with the version of cryptography (45.0.6), causing an `AttributeError`.

This change addresses the issue by:
1.  Explicitly adding `pyopenssl` to `requirements.in`. This forces pip-tools to resolve to a newer, compatible version of `pyopenssl`.
2.  Regenerating `requirements.txt` to reflect the updated dependencies. The new versions are `pyopenssl==24.3.0` and `cryptography==44.0.3`.

This resolves the startup error and allows the application to run correctly.