### PR TITLE
feat: Set timezone to Asia/Tehran

### DIFF
--- a/tournament_project/settings.py
+++ b/tournament_project/settings.py
@@ -179,7 +179,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "Asia/Tehran"
 
 USE_I18N = True
 


### PR DESCRIPTION
The `TIME_ZONE` setting in `tournament_project/settings.py` has been updated from `UTC` to `Asia/Tehran`.

This change configures the Django application to use the Tehran timezone, as requested by the user. This ensures that all date and time operations within the application are handled according to the specified timezone.