### PR TITLE
feat: Add description to TournamentListSerializer

### DIFF
--- a/tournaments/serializers.py
+++ b/tournaments/serializers.py
@@ -191,6 +191,7 @@ class TournamentListSerializer(TournamentReadOnlySerializer):
         fields = (
             "id",
             "name",
+            "description",
             "image",
             "game",
             "start_date",


### PR DESCRIPTION
The user requested to add the `description` field to the Game and Tournament serializers, stating it was forgotten in one of them.

Upon inspection, the `Game` serializers (`GameCreateUpdateSerializer` and `GameReadOnlySerializer`) already included the `description` field.

The `description` field was missing from the `TournamentListSerializer`, which is likely what the user was referring to. This commit adds the `description` field to the `TournamentListSerializer` to complete the data provided in the tournament list view.