### PR TITLE
feat: کانفیگ Nginx برای سرو کردن اپلیکیشن فرانت‌اند

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     build:
       context: ./nginx
     volumes:
+      - ./frontend:/var/www/frontend:ro
       - static_volume:/app/staticfiles
       - media_volume:/app/media
       - /etc/letsencrypt:/etc/letsencrypt:ro    # مسیر واقعی SSL

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,6 +23,12 @@ server {
     client_max_body_size 100m;
 
     location / {
+        root /var/www/frontend;
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        rewrite ^/api/(.*)$ /$1 break;
         proxy_pass http://web:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/tournament_project/urls.py
+++ b/tournament_project/urls.py
@@ -9,8 +9,8 @@ from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
 from tournaments.views import private_media_view
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("select2/", include("django_select2.urls")),
+    path("api/admin/", admin.site.urls),
+    path("api/select2/", include("django_select2.urls")),
     # Add drf-spectacular URLs
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(
@@ -28,9 +28,9 @@ urlpatterns = [
     path("api/chat/", include("chat.urls")),
     path("api/wallet/", include("wallet.urls")),
     path("api/notifications/", include("notifications.urls")),
-    re_path(r"^private-media/(?P<path>.*)$", private_media_view, name="private_media"),
-    path("auth/", include("djoser.urls")),
-    path("auth/", include("djoser.urls.jwt")),
+    re_path(r"^api/private-media/(?P<path>.*)$", private_media_view, name="private_media"),
+    path("api/auth/", include("djoser.urls")),
+    path("api/auth/", include("djoser.urls.jwt")),
     path("api/support/", include("support.urls")),
     path("api/verification/", include("verification.urls")),
     path("api/rewards/", include("rewards.urls")),
@@ -41,5 +41,5 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    urlpatterns += [path("silk/", include("silk.urls", namespace="silk"))]
+    urlpatterns += [path("api/silk/", include("silk.urls", namespace="silk"))]
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
این کامیت، زیرساخت لازم برای جداسازی و سرو کردن یک اپلیکیشن فرانت‌اند مستقل را فراهم می‌کند.

- Nginx اکنون فایل‌های استاتیک را از فولدر `/frontend` در مسیر `/` سرو می‌کند.
- تمام نقاط پایانی (endpoints) بک‌اند جنگو به مسیر `/api/` منتقل شده‌اند.
- فایل `docker-compose.yml` برای مانت کردن فولدر `frontend` در کانتینر Nginx آپدیت شد.
- تمام URLهای اصلی جنگو برای مطابقت با پیشوند `/api/` اصلاح شدند.