### PR TITLE
feat: Create Dashboard API Endpoint and Fix Bugs

### DIFF
--- a/tournaments/services.py
+++ b/tournaments/services.py
@@ -269,7 +269,12 @@ def join_tournament(
             "room_id": "placeholder-room-id",  # Replace with actual room ID
         }
         for member in members:
-            send_email_notification.delay(member.email, "Tournament Joined", context)
+            send_email_notification.delay(
+                member.email,
+                "Tournament Joined",
+                "notifications/email/tournament_joined.html",
+                context,
+            )
             send_sms_notification.delay(str(member.phone_number), context)
 
         return team


### PR DESCRIPTION
This commit introduces a new, optimized API endpoint at `/api/users/dashboard/` to serve all necessary data for the user dashboard in a single request.

Key changes include:

1.  **New `DashboardView`**: Created a new view that aggregates user profile information, a list of the user's teams, and their complete tournament history.
2.  **Optimized Query**: Implemented a custom `Prefetch` to resolve a critical N+1 query problem when fetching team data within the tournament history, significantly improving performance.
3.  **Comprehensive Testing**: Added a new test class, `DashboardViewTests`, to `users/tests.py`. This test validates the structure and correctness of the entire dashboard response, including profile data, teams, and tournament history for both individual and team-based tournaments.
4.  **Bug Fix in Notifications**: Corrected a `TypeError` in the `join_tournament` service by passing the required `template_name` argument to the `send_email_notification` Celery task. This bug was discovered during the full test run and was fixed to ensure project stability.

All existing and new tests pass, confirming that the new feature is correctly implemented and no regressions have been introduced.