### PR TITLE
feat(wallet): Enable Zarinpal sandbox mode by default

### DIFF
--- a/tournament_project/settings.py
+++ b/tournament_project/settings.py
@@ -339,7 +339,7 @@ AXES_COOLOFF_TIME = 1
 AXES_RESET_ON_SUCCESS = True
 
 ZARINPAL_MERCHANT_ID = os.environ.get("ZARINPAL_MERCHANT_ID", "")
-ZARINPAL_SANDBOX = os.environ.get("ZARINPAL_SANDBOX", "False").lower() in (
+ZARINPAL_SANDBOX = os.environ.get("ZARINPAL_SANDBOX", "True").lower() in (
     "true",
     "1",
     "t",

--- a/wallet/services.py
+++ b/wallet/services.py
@@ -10,7 +10,9 @@ from .models import Transaction, Wallet
 
 class ZarinpalService:
     def __init__(self):
-        self.zarinpal = ZarinPal(merchant_id=settings.ZARINPAL_MERCHANT_ID)
+        self.zarinpal = ZarinPal(
+            merchant_id=settings.ZARINPAL_MERCHANT_ID, sandbox=settings.ZARINPAL_SANDBOX
+        )
 
     def create_payment(
         self, amount, description, callback_url, mobile=None, email=None


### PR DESCRIPTION
This change configures the Zarinpal integration to use the sandbox environment by default for testing purposes.

The `ZarinpalService` is updated to respect the `ZARINPAL_SANDBOX` setting. The default value for `ZARINPAL_SANDBOX` in the settings is changed to `True` to ensure the sandbox is used unless explicitly disabled in a production environment via environment variables.