### PR TITLE
Fix: Remove unexpected 'sandbox' argument from ZarinPal constructor

### DIFF
--- a/wallet/services.py
+++ b/wallet/services.py
@@ -11,7 +11,7 @@ from .models import Transaction, Wallet
 class ZarinpalService:
     def __init__(self):
         self.zarinpal = ZarinPal(
-            merchant_id=settings.ZARINPAL_MERCHANT_ID, sandbox=settings.ZARINPAL_SANDBOX
+            merchant_id=settings.ZARINPAL_MERCHANT_ID
         )
 
     def create_payment(


### PR DESCRIPTION
The ZarinPal library (version 1.0.0) no longer accepts the 'sandbox' keyword argument in its constructor. This change removes the argument to prevent a TypeError during initialization.