### PR TITLE
feat: Make Wallet and Transaction admin pages editable

### DIFF
--- a/wallet/admin.py
+++ b/wallet/admin.py
@@ -28,12 +28,7 @@ class TransactionResource(resources.ModelResource):
 class TransactionInline(TabularInline):
     model = Transaction
     extra = 0
-    readonly_fields = ("amount", "transaction_type", "timestamp", "description")
-    can_delete = False
     show_change_link = True
-
-    def has_add_permission(self, request, obj=None):
-        return False
 
 
 # --- ModelAdmins (Upgraded) ---
@@ -41,11 +36,10 @@ class TransactionInline(TabularInline):
 @admin.register(Wallet)
 class WalletAdmin(ImportExportModelAdmin, SimpleHistoryAdmin, ModelAdmin):
     resource_class = WalletResource
-    list_display = ("user", "total_balance", "withdrawable_balance")
+    list_display = ("user", "total_balance", "withdrawable_balance", "token_balance")
     search_fields = ("user__username",)
     autocomplete_fields = ("user",)
     inlines = [TransactionInline]
-    readonly_fields = ("total_balance", "withdrawable_balance")
 
     formfield_overrides = {
         models.ForeignKey: {"widget": Select2Widget},
@@ -53,21 +47,20 @@ class WalletAdmin(ImportExportModelAdmin, SimpleHistoryAdmin, ModelAdmin):
 
     fieldsets = (
         ("Owner", {"fields": ("user",), "classes": ("tab",)}),
-        ("Balance", {"fields": ("total_balance", "withdrawable_balance"), "classes": ("tab",)}),
+        (
+            "Balance",
+            {
+                "fields": ("total_balance", "withdrawable_balance", "token_balance"),
+                "classes": ("tab",),
+            },
+        ),
     )
 
 
 @admin.register(Transaction)
 class TransactionAdmin(ImportExportModelAdmin, SimpleHistoryAdmin, ModelAdmin):
     resource_class = TransactionResource
-    list_display = ("wallet", "amount", "transaction_type", "timestamp")
-    list_filter = ("transaction_type", "timestamp")
+    list_display = ("wallet", "amount", "transaction_type", "timestamp", "status")
+    list_filter = ("transaction_type", "timestamp", "status")
     search_fields = ("wallet__user__username", "description")
     autocomplete_fields = ("wallet",)
-    readonly_fields = ("wallet", "amount", "transaction_type", "timestamp", "description")
-
-    def has_add_permission(self, request):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False


### PR DESCRIPTION
This change makes the Wallet and Transaction models editable in the Django admin panel, as requested by the user.

Key changes:
- Removed `readonly_fields` from `WalletAdmin` and `TransactionAdmin` to allow editing of all fields.
- Removed `has_add_permission` and `has_delete_permission` methods from `TransactionAdmin` to enable adding and deleting transactions.
- Removed restrictions from `TransactionInline` to allow editing, adding, and deleting transactions from the Wallet admin page.